### PR TITLE
1352 rename gobierto data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "savon"
-gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
+gem "gobierto_budgets_data", git: "https://github.com/PopulateTools/gobierto_budgets_data.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: 049295a35e7e18313e09d9fe479716c68ae423e1
+  remote: https://github.com/PopulateTools/gobierto_budgets_data.git
+  revision: 17761ea394fdb07418ee89a751482da4c6ebdaaf
   specs:
-    gobierto_data (0.1.0)
+    gobierto_budgets_data (0.1.0)
       actionpack
       activesupport
       aws-sdk-s3
@@ -131,7 +131,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  gobierto_data!
+  gobierto_budgets_data!
   savon
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cp .env.example .env && ln -s .env .rbenv-vars
 
 And fill in the values
 
-This repository relies heavily in [gobierto_data](https://github.com/PopulateTools/gobierto_data)
+This repository relies heavily in [gobierto_budgets_data](https://github.com/PopulateTools/gobierto_budgets_data)
 
 ## Available operations
 

--- a/operations/gobierto_budgets/import-executed-budgets/run.rb
+++ b/operations/gobierto_budgets/import-executed-budgets/run.rb
@@ -3,12 +3,12 @@
 require "bundler/setup"
 Bundler.require
 
-index = GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED
+index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED
 data_file = ARGV[0]
 year = ARGV[1].to_i
 
 puts "[START] import-executed-budgets/run.rb year=#{year} data_file=#{data_file}"
 
-nitems = GobiertoData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
+nitems = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
 
 puts "[END] import-executed-budgets/run.rb imported #{nitems} items"

--- a/operations/gobierto_budgets/import-planned-budgets/run.rb
+++ b/operations/gobierto_budgets/import-planned-budgets/run.rb
@@ -3,12 +3,12 @@
 require "bundler/setup"
 Bundler.require
 
-index = GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST
+index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST
 data_file = ARGV[0]
 year = ARGV[1].to_i
 
 puts "[START] import-planned-budgets/run.rb year=#{year} data_file=#{data_file}"
 
-nitems = GobiertoData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
+nitems = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
 
 puts "[END] import-planned-budgets/run.rb imported #{nitems} items"

--- a/operations/gobierto_budgets/transform-executed/run.rb
+++ b/operations/gobierto_budgets/transform-executed/run.rb
@@ -35,7 +35,7 @@ puts "[START] transform-executed/run.rb with file=#{input_file} output=#{output_
 json_data = JSON.parse(File.read(input_file))
 
 place = INE::Places::Place.find_by_slug('sant-feliu-de-llobregat')
-population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
 
 base_data = {
   organization_id: place.id,
@@ -55,7 +55,7 @@ def normalize_data(data, kind)
 
     amount = row["imp"].to_f
 
-    if kind == GobiertoData::GobiertoBudgets::EXPENSE
+    if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
       if row["prog"]
         # Level 3
         code = row["prog"][0..2]
@@ -72,7 +72,7 @@ def normalize_data(data, kind)
         normalized_data[code] ||= 0
         normalized_data[code] += amount
       end
-    elsif kind == GobiertoData::GobiertoBudgets::INCOME
+    elsif kind == GobiertoBudgetsData::GobiertoBudgets::INCOME
       # For income data, there's no children information, just first level
       code = row["cap"]
       normalized_data[code] ||= 0
@@ -91,7 +91,7 @@ def normalize_data_economic_expenses(data, kind)
 
     amount = row["imp"].to_f
 
-    if kind == GobiertoData::GobiertoBudgets::EXPENSE
+    if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
       code = row["cap"]
       normalized_data[code] ||= 0
       normalized_data[code] += amount
@@ -119,12 +119,12 @@ def hydratate(options)
 end
 
 normalized_data = normalize_data(json_data, kind)
-if(kind == GobiertoData::GobiertoBudgets::INCOME)
-  output_data = hydratate(data: normalized_data, area_name: GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME, kind: kind, base_data: base_data)
+if(kind == GobiertoBudgetsData::GobiertoBudgets::INCOME)
+  output_data = hydratate(data: normalized_data, area_name: GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME, kind: kind, base_data: base_data)
 else
-  output_data = hydratate(data: normalized_data, area_name: GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, kind: kind, base_data: base_data)
+  output_data = hydratate(data: normalized_data, area_name: GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, kind: kind, base_data: base_data)
   normalized_data = normalize_data_economic_expenses(json_data, kind)
-  output_data += hydratate(data: normalized_data, area_name: GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME, kind: kind, base_data: base_data)
+  output_data += hydratate(data: normalized_data, area_name: GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME, kind: kind, base_data: base_data)
 end
 
 File.write(output_file, output_data.to_json)

--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -33,7 +33,7 @@ puts "[START] transform-planned/run.rb with file=#{input_file} output=#{output_f
 json_data = JSON.parse(File.read(input_file))
 
 place = INE::Places::Place.find_by_slug('sant-feliu-de-llobregat')
-population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
 
 base_data = {
   organization_id: place.id,
@@ -103,9 +103,9 @@ end
 
 income_data, expenses_functional_data, expenses_economic_data = normalize_data(json_data)
 
-output_data = hydratate(data: income_data, area_name: GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME, kind: GobiertoData::GobiertoBudgets::INCOME, base_data: base_data) +
-                hydratate(data: expenses_functional_data, area_name: GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, kind: GobiertoData::GobiertoBudgets::EXPENSE, base_data: base_data) +
-                hydratate(data: expenses_economic_data, area_name: GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME, kind: GobiertoData::GobiertoBudgets::EXPENSE, base_data: base_data)
+output_data = hydratate(data: income_data, area_name: GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME, kind: GobiertoBudgetsData::GobiertoBudgets::INCOME, base_data: base_data) +
+                hydratate(data: expenses_functional_data, area_name: GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, kind: GobiertoBudgetsData::GobiertoBudgets::EXPENSE, base_data: base_data) +
+                hydratate(data: expenses_economic_data, area_name: GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME, kind: GobiertoBudgetsData::GobiertoBudgets::EXPENSE, base_data: base_data)
 
 File.write(output_file, output_data.to_json)
 


### PR DESCRIPTION
Related to PopulateTools/issues#1352

This PR replaces namespaces of `GobiertoData` with `GobiertoBudgetsData` and updates the gems dependency to point `gobierto_budgets_data` instead of `gobierto_data`