### PR TITLE
Fetch 2026 executed budget

### DIFF
--- a/pipelines/budgets/Jenkinsfile
+++ b/pipelines/budgets/Jenkinsfile
@@ -26,8 +26,8 @@ pipeline {
               sh '''#!/bin/bash
                 source ${SANTFELIU_ETL}/.rbenv-vars;
                 cd ${GOBIERTO_ETL_UTILS};
-                ruby operations/download/run.rb 'https://www.santfeliu.cat/scripts/pressupost_despesa?execute&any=25'  ${STORAGE_DIR}/budgets-executed-expense-2025.json --compatible;
-                ruby operations/download/run.rb 'https://www.santfeliu.cat/scripts/pressupost_ingres?execute&any=25'   ${STORAGE_DIR}/budgets-executed-income-2025.json --compatible;
+                ruby operations/download/run.rb 'https://www.santfeliu.cat/scripts/pressupost_despesa?execute&any=26'  ${STORAGE_DIR}/budgets-executed-expense-2026.json --compatible;
+                ruby operations/download/run.rb 'https://www.santfeliu.cat/scripts/pressupost_ingres?execute&any=26'   ${STORAGE_DIR}/budgets-executed-income-2026.json --compatible;
                 ruby operations/download/run.rb 'https://www.santfeliu.cat/scripts/previsio_pressupost?execute&any=26&key='$SANT_FELIU_API_TOKEN ${STORAGE_DIR}/budgets-planned-2026.json --compatible;
                 sleep 30;
               '''
@@ -35,15 +35,15 @@ pipeline {
         }
         stage('Extract > Check valid JSON') {
             steps {
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-json/run.rb ${STORAGE_DIR}/budgets-executed-expense-2025.json"
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-json/run.rb ${STORAGE_DIR}/budgets-executed-income-2025.json"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-json/run.rb ${STORAGE_DIR}/budgets-executed-expense-2026.json"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-json/run.rb ${STORAGE_DIR}/budgets-executed-income-2026.json"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-json/run.rb ${STORAGE_DIR}/budgets-planned-2026.json"
             }
         }
         stage('Extract > Check data source columns') {
             steps {
-                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/check-json-columns/run.rb ${STORAGE_DIR}/budgets-executed-expense-2025.json"
-                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/check-json-columns/run.rb ${STORAGE_DIR}/budgets-executed-income-2025.json"
+                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/check-json-columns/run.rb ${STORAGE_DIR}/budgets-executed-expense-2026.json"
+                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/check-json-columns/run.rb ${STORAGE_DIR}/budgets-executed-income-2026.json"
                 sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/check-json-columns/run.rb ${STORAGE_DIR}/budgets-planned-2026.json"
             }
         }
@@ -54,8 +54,8 @@ pipeline {
         }
         stage('Transform > Transform executed budgets data files') {
             steps {
-                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${STORAGE_DIR}/budgets-executed-expense-2025.json ${STORAGE_DIR}/budgets-executed-expense-2025-transformed.json 2025 G"
-                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${STORAGE_DIR}/budgets-executed-income-2025.json  ${STORAGE_DIR}/budgets-executed-income-2025-transformed.json 2025 I"
+                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${STORAGE_DIR}/budgets-executed-expense-2026.json ${STORAGE_DIR}/budgets-executed-expense-2026-transformed.json 2026 G"
+                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${STORAGE_DIR}/budgets-executed-income-2026.json  ${STORAGE_DIR}/budgets-executed-income-2026-transformed.json 2026 I"
             }
         }
         stage('Load > Import planned budgets') {
@@ -65,14 +65,14 @@ pipeline {
         }
         stage('Load > Import executed budgets') {
             steps {
-                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${STORAGE_DIR}/budgets-executed-expense-2025-transformed.json 2025"
-                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${STORAGE_DIR}/budgets-executed-income-2025-transformed.json 2025"
+                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${STORAGE_DIR}/budgets-executed-expense-2026-transformed.json 2026"
+                sh "cd ${SANTFELIU_ETL}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${STORAGE_DIR}/budgets-executed-income-2026-transformed.json 2026"
             }
         }
         stage('Load > Calculate totals') {
             steps {
               sh "echo '${SANT_FELIU_INE_CODE}' > ${STORAGE_DIR}/organization.id.txt"
-              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/update_total_budget/run.rb '2026 2025' ${STORAGE_DIR}/organization.id.txt"
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/update_total_budget/run.rb '2026' ${STORAGE_DIR}/organization.id.txt"
             }
         }
         stage('Load > Calculate bubbles') {
@@ -82,7 +82,7 @@ pipeline {
         }
         stage('Load > Calculate annual data') {
             steps {
-              sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto_budgets/annual_data/run.rb '2025 2026' ${STORAGE_DIR}/organization.id.txt"
+              sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto_budgets/annual_data/run.rb '2026' ${STORAGE_DIR}/organization.id.txt"
             }
         }
         stage('Load > Publish activity') {


### PR DESCRIPTION
Moves the Sant Feliu budgets ETL pipeline (`pipelines/budgets/Jenkinsfile`) to fetch **executed** budgets (expense and income) for year **2026** instead of 2025, dropping all 2025 extractions. Planned budgets were already on 2026, so the pipeline now processes 2026 only. The "Calculate totals" and "Calculate annual data" year lists are collapsed to `2026`, matching the established single-year-transition pattern (e.g. commit `f1141a8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)